### PR TITLE
Update titles for better SEO and Social Card Relevance

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,9 +5,9 @@ permalink: /cocktails/:year/:month/:day/:title/
 google_analytics: 
   id: "UA-143299729-1"
 
-title: Paine × MacTane
+title: The Expanse Cocktails Project
 description: >
-  Paine × MacTane: a transcontinental pair of sci-fi fans, language enthusiasts, cocktail creators, and perpetual learners and teachers.
+  Expanse Cocktails created by Paine × MacTane: a transcontinental pair of sci-fi fans, language enthusiasts, cocktail creators, and perpetual learners and teachers.
 url: https://www.painemactane.com
 twitter_username: Paine_MacTane
 default_img: /assets/images/site-image.jpg

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,7 +2,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 
-<title>{% if page.title %}{{ page.title | escape }} | {{ site.title }}{% else %}{{ site.title | escape }}{% endif %}</title>
+<title>{% if page.title_override %} {{page.title_override | escape}} {% elsif page.title %}{{ page.title | escape }} | {{ site.title }}{% else %}{{ site.title | escape }}{% endif %}</title>
 <meta name="description" content="{% if page.description %}{{ page.description | escape }}{% elsif page.content %}{{ page.content | strip_html | escape | truncatewords: 50 }}{% else %}{{ site.description }}{% endif %}">
 
 <meta itemprop="name" content="{{ site.name }}">
@@ -11,14 +11,14 @@
 
 <meta property="og:url" content="{{ page.url | absolute_url }}">
 <meta property="og:type" content="website">
-<meta property="og:title" content="{% if page.title %}{{ page.title | escape }} | {{ site.title }}{% else %}{{ site.title | escape }}{% endif %}">
+<meta property="og:title" content="{% if page.title_override %} {{page.title_override | escape}} {% elsif page.title %}{{ page.title | escape }} | {{ site.title }}{% else %}{{ site.title | escape }}{% endif %}">
 <meta property="og:site_name" content="{{ site.title }}">
 <meta property="og:description" content="{% if page.description %}{{ page.description | escape }}{% elsif page.content %}{{ page.content | strip_html | escape | truncatewords: 50 }}{% else %}{{ site.description }}{% endif %}">
 <meta property="og:image" content="{% if page.social_image %}{{ page.social_image | absolute_url }}{% elsif page.hero %}{{page.hero | absolute_url}}{% else %}{{ site.default_img | absolute_url }}{% endif %}">
 
 <meta name="twitter:url" content="{{ page.url | absolute_url }}">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="{% if page.title %}{{ page.title | escape }} | {{ site.title }}{% else %}{{ site.title | escape }}{% endif %}">
+<meta name="twitter:title" content="{% if page.title_override %} {{page.title_override | escape}} {% elsif page.title %}{{ page.title | escape }} | {{ site.title }}{% else %}{{ site.title | escape }}{% endif %}">
 <meta name="twitter:site" content="{{ site.title }}">
 <meta name="twitter:description" content="{% if page.description %}{{ page.description | escape }}{% elsif page.content %}{{ page.content | strip_html | escape | truncatewords: 50 }}{% else %}{{ site.description }}{% endif %}">
 {% if site.twitter_username %}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,5 +1,5 @@
 <header class="header">
-  <a class="header__title" href="{{ '/' | absolute_url }}">{{ site.title }}</a>
+  <a class="header__title" href="{{ '/' | absolute_url }}">{% if page.title_override %} {{page.title_override}} {% else %}{{ site.title }} {% endif %}</a>
 
   {% include navigation.html %}
 </header>

--- a/cocktails/index.html
+++ b/cocktails/index.html
@@ -1,7 +1,8 @@
 ---
 layout: default
 social_image: /assets/images/cocktails-default.jpg
-description: "Cocktails created by Paine × MacTane: a transcontinental pair of sci-fi fans, language enthusiasts, cocktail creators, and perpetual learners and teachers."
+description: "Expanse Cocktails created by Paine × MacTane: a transcontinental pair of sci-fi fans, language enthusiasts, cocktail creators, and perpetual learners and teachers."
+title_override: The Expanse Cocktails Project
 pagination:
   enabled: true
 ---

--- a/index.md
+++ b/index.md
@@ -1,6 +1,8 @@
 ---
 layout: about
 description: "Paine × MacTane: a transcontinental pair of sci-fi fans, language enthusiasts, cocktail creators, and perpetual learners and teachers."
+title: Paine × MacTane
+title_override: Paine × MacTane
 ---
 <!-- The main content area -->
 # About Us


### PR DESCRIPTION
This adds a "title_override" field that can be used on certain
pages to specify entirely what the title should be for social
and SEO purposes. In addition, the overall title in the config
is changed to "The Expanse Cocktails Project", since that's a
better site title for all but one of the pages. The cocktails
index is now changed to having a title_override of
"The Expanse Cocktails Project", and the root index page is changed
to overriding to the original "Paine x Mactane". The title override
currently also overrides the text displayed in the top left nav.

An additional change to make "The Expanse Cocktails Project" link
to the right place in the nav may also be helpful.